### PR TITLE
workaround for Read timed out.

### DIFF
--- a/crawlfrontier/contrib/backends/hcf/__init__.py
+++ b/crawlfrontier/contrib/backends/hcf/__init__.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 import datetime
+import requests
+import time
 
 from hubstorage import HubstorageClient
 
@@ -58,10 +60,21 @@ class HCFManager(object):
         return n_links_to_flush
 
     def read(self, slot, mincount=None):
-        return self._hcf.read(self._frontier, slot, mincount)
+        for i in range(10):
+            try:
+                return self._hcf.read(self._frontier, slot, mincount)
+            except requests.exceptions.ReadTimeout:
+                time.sleep(60)
+                continue
+        return []
 
     def delete(self, slot, ids):
-        self._hcf.delete(self._frontier, slot, ids)
+        for i in range(10):
+            try:
+                self._hcf.delete(self._frontier, slot, ids)
+            except requests.exceptions.ReadTimeout:
+                time.sleep(60)
+                continue
 
     def delete_slot(self, slot):
         self._hcf.delete_slot(self._frontier, slot)


### PR DESCRIPTION
This should take care of errors such as:
```
File "/usr/lib/python2.7/dist-packages/hubstorage/resourcetype.py", line 34, in apirequest
	    return jldecode(self._iter_lines(_path, **kwargs))
	  File "/usr/lib/python2.7/dist-packages/hubstorage/resourcetype.py", line 27, in _iter_lines
	    r = self.client.session.request(**kwargs)
	  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 451, in request
	    resp = self.send(prep, **send_kwargs)
	  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 557, in send
	    r = adapter.send(request, **kwargs)
	  File "/usr/lib/python2.7/dist-packages/requests/adapters.py", line 422, in send
	    raise ReadTimeout(e, request=request)
	requests.exceptions.ReadTimeout: HTTPConnectionPool(host='storage.scrapinghub.com', port=80): Read timed out. (read timeout=60.0)
```