### PR TITLE
usage of tldextract is responsible of a significative performance decrease

### DIFF
--- a/crawlfrontier/settings/default_settings.py
+++ b/crawlfrontier/settings/default_settings.py
@@ -6,9 +6,7 @@ import logging
 REQUEST_MODEL = 'crawlfrontier.core.models.Request'
 RESPONSE_MODEL = 'crawlfrontier.core.models.Response'
 MIDDLEWARES = [
-    'crawlfrontier.contrib.middlewares.domain.DomainMiddleware',
     'crawlfrontier.contrib.middlewares.fingerprint.UrlFingerprintMiddleware',
-    'crawlfrontier.contrib.middlewares.fingerprint.DomainFingerprintMiddleware',
 ]
 BACKEND = 'crawlfrontier.contrib.backends.memory.FIFO'
 TEST_MODE = False

--- a/docs/source/topics/frontier-settings.rst
+++ b/docs/source/topics/frontier-settings.rst
@@ -140,9 +140,7 @@ A list containing the middlewares enabled in the frontier. For more info see
 Default::
 
     [
-        'crawlfrontier.contrib.middlewares.domain.DomainMiddleware',
         'crawlfrontier.contrib.middlewares.fingerprint.UrlFingerprintMiddleware',
-        'crawlfrontier.contrib.middlewares.fingerprint.DomainFingerprintMiddleware',
     ]
 
 .. setting:: REQUEST_MODEL
@@ -220,9 +218,7 @@ Values::
     LINK_MODEL = 'crawlfrontier.core.models.Link'
     FRONTIER = 'crawlfrontier.core.frontier.Frontier'
     MIDDLEWARES = [
-        'crawlfrontier.contrib.middlewares.domain.DomainMiddleware',
         'crawlfrontier.contrib.middlewares.fingerprint.UrlFingerprintMiddleware',
-        'crawlfrontier.contrib.middlewares.fingerprint.DomainFingerprintMiddleware',
     ]
     BACKEND = 'crawlfrontier.contrib.backends.memory.FIFO'
     TEST_MODE = False


### PR DESCRIPTION
@sibiryakov  as you suggested I have profiled jobs and process spents an important amount of time (near 30-40% of total) in cPickle.load() method, which is used by tldextract. Disabling DomainMiddleware jobs works much faster, and are not needed by any CF component. So this middleware should be enabled only when required.

