### PR TITLE
Fixing hitting get_next_requests on each attempt to get buffered request

### DIFF
--- a/crawlfrontier/contrib/scrapy/schedulers/frontier.py
+++ b/crawlfrontier/contrib/scrapy/schedulers/frontier.py
@@ -75,7 +75,7 @@ class CrawlFrontierScheduler(Scheduler):
         self.stats_manager = StatsManager(crawler.stats)
         self._pending_requests = deque()
         self.redirect_enabled = crawler.settings.get('REDIRECT_ENABLED')
-        self._delay_next_call = clock()
+        self._delay_next_call = 0.0
 
         frontier_settings = crawler.settings.get('FRONTIER_SETTINGS', None)
         if not frontier_settings:

--- a/crawlfrontier/contrib/scrapy/schedulers/frontier.py
+++ b/crawlfrontier/contrib/scrapy/schedulers/frontier.py
@@ -147,12 +147,6 @@ class CrawlFrontierScheduler(Scheduler):
             requests = self.frontier.get_next_requests(key_type=info['key_type'], overused_keys=info['overused_keys'])
             for request in requests:
                 self._add_pending_request(request)
-
-            '''
-            If we got empty requests list, it means backend has nothing to return. Delay will help us to exhaust
-            the rest of the buffer and inform the code upper on the stack, that current buffer is empty, without
-            hitting backend on every request.
-            '''
             self._delay_next_call = time() + self._delay_on_empty if not requests else 0.0
         return self._get_pending_request()
 

--- a/crawlfrontier/contrib/scrapy/schedulers/frontier.py
+++ b/crawlfrontier/contrib/scrapy/schedulers/frontier.py
@@ -3,7 +3,7 @@ from scrapy.http import Request
 from scrapy import log
 
 from collections import deque
-from time import clock
+from time import time
 
 from crawlfrontier.contrib.scrapy.manager import ScrapyFrontierManager
 
@@ -141,7 +141,7 @@ class CrawlFrontierScheduler(Scheduler):
     def _get_next_request(self):
         if not self.frontier.manager.finished and \
                         len(self) < self.crawler.engine.downloader.total_concurrency and \
-                        self._delay_next_call < clock():
+                        self._delay_next_call < time():
 
             info = self._get_downloader_info()
             requests = self.frontier.get_next_requests(key_type=info['key_type'], overused_keys=info['overused_keys'])
@@ -153,7 +153,7 @@ class CrawlFrontierScheduler(Scheduler):
             the rest of the buffer and inform the code upper on the stack, that current buffer is empty, without
             hitting backend on every request.
             '''
-            self._delay_next_call = clock() + self._delay_on_empty if not requests else 0.0
+            self._delay_next_call = time() + self._delay_on_empty if not requests else 0.0
         return self._get_pending_request()
 
     def _add_pending_request(self, request):

--- a/crawlfrontier/contrib/scrapy/schedulers/frontier.py
+++ b/crawlfrontier/contrib/scrapy/schedulers/frontier.py
@@ -140,8 +140,8 @@ class CrawlFrontierScheduler(Scheduler):
 
     def _get_next_request(self):
         if not self.frontier.manager.finished and \
-                        len(self) < self.crawler.engine.downloader.total_concurrency and \
-                        self._delay_next_call < time():
+                len(self) < self.crawler.engine.downloader.total_concurrency and \
+                self._delay_next_call < time():
 
             info = self._get_downloader_info()
             requests = self.frontier.get_next_requests(key_type=info['key_type'], overused_keys=info['overused_keys'])

--- a/crawlfrontier/contrib/scrapy/schedulers/frontier.py
+++ b/crawlfrontier/contrib/scrapy/schedulers/frontier.py
@@ -3,6 +3,7 @@ from scrapy.http import Request
 from scrapy import log
 
 from collections import deque
+from time import clock
 
 from crawlfrontier.contrib.scrapy.manager import ScrapyFrontierManager
 
@@ -74,6 +75,7 @@ class CrawlFrontierScheduler(Scheduler):
         self.stats_manager = StatsManager(crawler.stats)
         self._pending_requests = deque()
         self.redirect_enabled = crawler.settings.get('REDIRECT_ENABLED')
+        self._delay_next_call = clock()
 
         frontier_settings = crawler.settings.get('FRONTIER_SETTINGS', None)
         if not frontier_settings:
@@ -136,10 +138,18 @@ class CrawlFrontierScheduler(Scheduler):
 
     def _get_next_request(self):
         if not self.frontier.manager.finished and \
-                len(self) < self.crawler.engine.downloader.total_concurrency:
+                len(self) < self.crawler.engine.downloader.total_concurrency and \
+                self._delay_next_call < clock():
+
             info = self._get_downloader_info()
-            for request in self.frontier.get_next_requests(key_type=info['key_type'], overused_keys=info['overused_keys']):
+            requests = self.frontier.get_next_requests(key_type=info['key_type'], overused_keys=info['overused_keys'])
+            for request in requests:
                 self._add_pending_request(request)
+
+            # If we got empty requests list, it means backend has nothing to return. Delay will help us to exhaust 
+            # the rest of the buffer and inform the code upper on the stack, that current buffer is empty, without 
+            # hitting backend on every request.
+            self._delay_next_call = clock() + 30.0 if not requests else 0.0
         return self._get_pending_request()
 
     def _add_pending_request(self, request):

--- a/crawlfrontier/contrib/scrapy/schedulers/frontier.py
+++ b/crawlfrontier/contrib/scrapy/schedulers/frontier.py
@@ -138,17 +138,19 @@ class CrawlFrontierScheduler(Scheduler):
 
     def _get_next_request(self):
         if not self.frontier.manager.finished and \
-                len(self) < self.crawler.engine.downloader.total_concurrency and \
-                self._delay_next_call < clock():
+                        len(self) < self.crawler.engine.downloader.total_concurrency and \
+                        self._delay_next_call < clock():
 
             info = self._get_downloader_info()
             requests = self.frontier.get_next_requests(key_type=info['key_type'], overused_keys=info['overused_keys'])
             for request in requests:
                 self._add_pending_request(request)
 
-            # If we got empty requests list, it means backend has nothing to return. Delay will help us to exhaust 
-            # the rest of the buffer and inform the code upper on the stack, that current buffer is empty, without 
-            # hitting backend on every request.
+            '''
+            If we got empty requests list, it means backend has nothing to return. Delay will help us to exhaust
+            the rest of the buffer and inform the code upper on the stack, that current buffer is empty, without
+            hitting backend on every request.
+            '''
             self._delay_next_call = clock() + 30.0 if not requests else 0.0
         return self._get_pending_request()
 

--- a/crawlfrontier/settings/default_settings.py
+++ b/crawlfrontier/settings/default_settings.py
@@ -14,6 +14,7 @@ MAX_REQUESTS = 0
 MAX_NEXT_REQUESTS = 0
 AUTO_START = True
 OVERUSED_SLOT_FACTOR = 5.0
+DELAY_ON_EMPTY = 30.0
 
 #--------------------------------------------------------
 # Fingerprints mw

--- a/docs/source/topics/frontier-settings.rst
+++ b/docs/source/topics/frontier-settings.rst
@@ -173,6 +173,18 @@ Default: ``False``
 Whether to enable frontier test mode. See :ref:`Frontier test mode <frontier-test-mode>`
 
 
+.. setting:: DELAY_ON_EMPTY
+
+DELAY_ON_EMPTY
+--------------
+
+Default: ``30.0``
+
+When backend has no requests to fetch, this delay helps to exhaust the rest of the buffer without hitting
+backend on every request. Increase it if calls to your backend is taking a lot of time, and decrease if you need a fast
+spider bootstrap from seeds.
+
+
 Built-in fingerprint middleware settings
 ========================================
 


### PR DESCRIPTION
When it's not possible to fully fill the downloader queue, get_next_requests is called on each scheduler's attempt to get new request in Scrapy Engine. Resulting to blocking the event loop and timing out of requests that are already in the queue.

The solution in this PR introduces 30 seconds delay when backend is returning zero results, allowing rest of the schedulers buffer to exhaust, event loop to unblock and continue processing the queue.